### PR TITLE
Update the icon used to represent available cards for better visibility

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -130,7 +130,7 @@
             <div class="col-12">
                 <div class="game-actions-bar text-center">
                     <button type="button" class="btn btn-outline-primary" id="toggle-cards-btn" onclick="toggleAvailableCards()">
-                        <i class="fas fa-cards-blank"></i> Cartes disponibles
+                        <i class="fas fa-th-large"></i> Cartes disponibles
                     </button>
                     <button class="btn btn-outline-info" onclick="showRules()">
                         <i class="fas fa-book"></i> Règles


### PR DESCRIPTION
Replaces the fa-cards-blank Font Awesome icon with fa-th-large in index.html.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 30efe45d-b709-4f07-ad7e-1383a96e8d30
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8d6543eb-deaa-4856-abb4-4cc16a2f6c64/30efe45d-b709-4f07-ad7e-1383a96e8d30/ajzK7jA