### PR TITLE
Improve image generation with card-specific references and browser fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -217,8 +217,9 @@ def envoyer():
 
             # Generate actual image using Replicate API
             try:
+                card_name = card.get('mot', '') if card else ''
                 image_result = generate_card_image_with_replicate(
-                    image_prompt, player_name, card_number)
+                    image_prompt, player_name, card_number, card_name)
                 if image_result.get("success"):
                     logger.info(
                         f"Actual image generated successfully for card {card_number}"
@@ -517,10 +518,12 @@ def serve_result_file(filename):
             logger.error(f"Image file not found: {file_path}")
             return jsonify({'error': 'Image non trouvée'}), 404
             
-        # Send file with proper headers
+        # Send file with proper headers for Chrome compatibility
         response = send_from_directory('result', filename)
         response.headers['Cache-Control'] = 'public, max-age=3600'  # Cache for 1 hour
         response.headers['Access-Control-Allow-Origin'] = '*'  # Allow CORS
+        response.headers['Cross-Origin-Resource-Policy'] = 'cross-origin'  # Chrome fix
+        response.headers['X-Content-Type-Options'] = 'nosniff'  # Chrome security
         return response
         
     except Exception as e:

--- a/deck.json
+++ b/deck.json
@@ -121,7 +121,7 @@
     },
     {
         "numero": "2",
-        "mot": "Mariée",
+        "mot": "Mariee",
         "phrase": "Une femme en robe de mariée avec une couronne de fleurs.",
         "descriptif": "L'image montre une femme en robe de mariée blanche, avec une couronne de fleurs sur la tête, debout sur un fond vert uni."
     },

--- a/game_logic.py
+++ b/game_logic.py
@@ -505,14 +505,14 @@ Je ne veux que le prompt en retour. Il ne faut pas d'explication en plus."""
     return call_mistral_ai(prompt)
 
 
-def generate_card_image_with_replicate(prompt: str, player_name: str, card_number: int) -> dict:
+def generate_card_image_with_replicate(prompt: str, player_name: str, card_number: int, card_name: str = "") -> dict:
     """Generate an actual image using Replicate API based on the Mistral-generated prompt"""
     try:
         # Import the image generator module
         from image_generator import generate_card_image
         
-        logger.info(f"Generating actual image for card {card_number} by {player_name}")
-        result = generate_card_image(prompt, player_name, card_number)
+        logger.info(f"Generating actual image for card {card_number} ({card_name}) by {player_name}")
+        result = generate_card_image(prompt, player_name, card_number, card_name=card_name)
         
         if result.get("success"):
             logger.info(f"Image generation successful: {len(result.get('images', []))} images created")


### PR DESCRIPTION
Pass card name to image generator for reference image URL; adds Chrome CORS headers.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 30efe45d-b709-4f07-ad7e-1383a96e8d30
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8d6543eb-deaa-4856-abb4-4cc16a2f6c64/30efe45d-b709-4f07-ad7e-1383a96e8d30/9pibQ4N