### PR TITLE
Improve handling of special characters when generating image URLs

### DIFF
--- a/image_generator.py
+++ b/image_generator.py
@@ -20,8 +20,9 @@ DEFAULT_IMAGE_REF = "http://www.barbason.be/public/mariee.jpg"
 def get_card_reference_image(card_name):
     """Construit l'URL de l'image de référence basée sur le nom de la carte."""
     if card_name:
-        # Nettoyer le nom de la carte pour l'URL
-        clean_name = card_name.lower().replace(' ', '').replace('é', 'e').replace('è', 'e').replace('ï', 'i')
+        # Utiliser unidecode pour convertir tous les caractères accentués
+        from unidecode import unidecode
+        clean_name = unidecode(card_name).lower().replace(' ', '')
         card_url = f"http://www.barbason.be/public/{clean_name}.jpg"
         
         # Vérifier rapidement si l'URL existe (timeout court)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "replicate>=1.0.7",
     "requests>=2.32.4",
+    "unidecode>=1.4.0",
 ]

--- a/replit.md
+++ b/replit.md
@@ -75,12 +75,15 @@ Created comprehensive game rules document (`RÈGLES_DU_JEU.md`) covering:
     - Updated story creation logic to link successful image generation to story entries
     - **Bug Fix**: Corrected image filename extraction from Replicate API response structure
     - **Enhancement**: Improved `/result/<filename>` route with better error handling, CORS headers, and security checks
+    - **Card Reference Images**: Added system to use card-specific reference images from `http://www.barbason.be/public/{cardname}.jpg`
+    - **Character Handling**: Integrated `unidecode` library for proper handling of accented characters in card names
   - **Frontend Display**:
     - Modified `updateStoryDisplay()` function to render images alongside story text
     - Added responsive layout with story text on left, image thumbnail on right
     - Implemented clickable images that open full-size versions in new tabs
     - Added loading="lazy" for better performance with multiple images
     - **Debug Enhancement**: Added console logging for image loading diagnostics
+    - **Chrome Compatibility**: Fixed image display issues in Chrome with additional HTTP headers
   - **CSS Styling**:
     - Added `.story-content`, `.story-text`, and `.story-image` classes for responsive layout
     - Implemented hover effects with scaling and accent border highlighting
@@ -89,8 +92,9 @@ Created comprehensive game rules document (`RÈGLES_DU_JEU.md`) covering:
   - **Debugging Tools**:
     - Created `test_image_route.py` script for local server diagnostics
     - Added `debug_images.html` for visual testing of image display functionality
+    - Added `/debug` and `/debug/images` endpoints for troubleshooting
 - **Impact**: Players now see visual representations of their card effects directly in the game interface, creating an immersive multimedia storytelling experience
-- **Status**: ✅ Completed on Replit - Working on local server compatibility improvements
+- **Status**: ✅ Completed - Images display correctly in both Firefox and Chrome, with card-specific reference images
 
 ### July 21, 2025 - Complete Special Cards System Implementation
 - **Special Cards Implementation**: Added both carte 100 "Inversion" and carte 101 "Suppression" with unique game-changing mechanics

--- a/uv.lock
+++ b/uv.lock
@@ -571,6 +571,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "replicate" },
     { name = "requests" },
+    { name = "unidecode" },
 ]
 
 [package.metadata]
@@ -584,6 +585,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "replicate", specifier = ">=1.0.7" },
     { name = "requests", specifier = ">=2.32.4" },
+    { name = "unidecode", specifier = ">=1.4.0" },
 ]
 
 [[package]]
@@ -681,6 +683,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552 },
+]
+
+[[package]]
+name = "unidecode"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add unidecode library to image_generator.py to handle accented characters in card names.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 30efe45d-b709-4f07-ad7e-1383a96e8d30
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8d6543eb-deaa-4856-abb4-4cc16a2f6c64/30efe45d-b709-4f07-ad7e-1383a96e8d30/9pibQ4N