### PR TITLE
Improve image display on Firefox Android for a better user experience

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -182,6 +182,88 @@ body::before {
         display: -webkit-flex;
         display: flex;
     }
+    
+    /* Force image aspect ratio in Firefox */
+    .story-image img {
+        aspect-ratio: 5/7 !important; /* Portrait ratio */
+        object-fit: contain !important;
+        width: 100% !important;
+        height: auto !important;
+        min-height: 140px !important;
+    }
+}
+
+/* Additional Firefox Android specific fixes */
+@supports (-moz-appearance: none) {
+    /* Firefox Android specific CSS */
+    .story-image {
+        width: 100px !important;
+        height: 140px !important;
+        overflow: hidden;
+        border-radius: 8px;
+        border: 2px solid var(--border-color);
+        background-color: var(--secondary-color);
+    }
+    
+    .story-image img {
+        width: 100% !important;
+        height: 100% !important;
+        object-fit: contain !important;
+        object-position: center !important;
+        display: block !important;
+    }
+}
+
+/* Mobile Firefox specific media query */
+@media screen and (max-width: 768px) and (-moz-appearance: none) {
+    .story-image {
+        width: 200px !important;
+        height: 280px !important;
+        max-width: 200px !important;
+    }
+    
+    .story-image img {
+        width: 100% !important;
+        height: 100% !important;
+        object-fit: contain !important;
+    }
+}
+
+/* Ultimate fallback for Firefox Android using user-agent detection */
+@media screen and (max-device-width: 768px) {
+    .story-image {
+        display: block !important;
+        width: 200px !important;
+        height: 280px !important;
+        max-width: 200px !important;
+        max-height: 280px !important;
+        overflow: hidden !important;
+        background: var(--secondary-color) !important;
+        border: 2px solid var(--border-color) !important;
+        border-radius: 8px !important;
+        flex-shrink: 0 !important;
+    }
+    
+    .story-image img {
+        width: 100% !important;
+        height: 100% !important;
+        max-width: 100% !important;
+        max-height: 100% !important;
+        object-fit: contain !important;
+        object-position: center !important;
+        display: block !important;
+        border-radius: 6px !important;
+    }
+    
+    /* Simplified approach for Firefox Android */
+    .story-content {
+        flex-direction: column !important;
+    }
+    
+    .story-image {
+        align-self: center !important;
+        margin: 10px 0 !important;
+    }
 }
 
 /* Additional mobile story display fixes */

--- a/static/js/game.js
+++ b/static/js/game.js
@@ -1402,6 +1402,23 @@ function applyFirefoxAndroidFixes() {
             margin-bottom: 8px !important;
             color: var(--accent-color) !important;
         }
+        .firefox-android .story-image {
+            width: 200px !important;
+            height: 280px !important;
+            overflow: hidden !important;
+            border-radius: 8px !important;
+            border: 2px solid var(--border-color) !important;
+            background-color: var(--secondary-color) !important;
+            display: block !important;
+        }
+        .firefox-android .story-image img {
+            width: 100% !important;
+            height: 100% !important;
+            object-fit: contain !important;
+            object-position: center !important;
+            display: block !important;
+            aspect-ratio: 5/7 !important;
+        }
     `;
     document.head.appendChild(style);
     
@@ -1436,6 +1453,20 @@ if (navigator.userAgent.toLowerCase().includes('firefox') &&
         setTimeout(applyFirefoxAndroidFixes, 50);
         return result;
     };
+    
+    // Additional periodic fix application for Firefox Android
+    setInterval(function() {
+        var images = document.querySelectorAll('.story-image img');
+        images.forEach(function(img) {
+            if (img.style.width !== '100%' || img.style.height !== '100%') {
+                img.style.width = '100%';
+                img.style.height = '100%';
+                img.style.objectFit = 'contain';
+                img.style.display = 'block';
+                console.log('Re-applied Firefox Android image fixes');
+            }
+        });
+    }, 2000);
 }
 
 function saveSpeechConfig() {


### PR DESCRIPTION
Adds CSS and JS fixes to maintain image aspect ratio and styling in Firefox Android.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 30efe45d-b709-4f07-ad7e-1383a96e8d30
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/8d6543eb-deaa-4856-abb4-4cc16a2f6c64/30efe45d-b709-4f07-ad7e-1383a96e8d30/LllWCHJ